### PR TITLE
remove underscores from tool names.

### DIFF
--- a/xml_files/alternative_genes_pathwaymapper.xml
+++ b/xml_files/alternative_genes_pathwaymapper.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_alternative_genes_pathwaymapper" name="PanCancer_alternative_genes_pathwaymapper" version="@VERSION@">
+<tool id="pancancer_alternative_genes_pathwaymapper" name="PanCancer alternative genes pathwaymapper" version="@VERSION@">
     <description>alternative genes pathwaymapper</description>
     <macros>
         <import>macros.xml</import>

--- a/xml_files/compare_within_models.xml
+++ b/xml_files/compare_within_models.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_compare_within_models" name="PanCancer_compare_within_models" version="@VERSION@">
+<tool id="pancancer_compare_within_models" name="PanCancer compare within models" version="@VERSION@">
     <description>compare within models</description>
     <macros>
         <import>macros.xml</import>

--- a/xml_files/external_sample_status_prediction.xml
+++ b/xml_files/external_sample_status_prediction.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_external_sample_status_prediction" name="PanCancer_external_sample_status_prediction" version="@VERSION@">
+<tool id="pancancer_external_sample_status_prediction" name="PanCancer external sample status prediction" version="@VERSION@">
     <description>external sample status</description>
     <macros>
         <import>macros.xml</import>

--- a/xml_files/map_mutation_class.xml
+++ b/xml_files/map_mutation_class.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_map_mutation_class" name="PanCancer_map_mutation_class" version="@VERSION@">
+<tool id="pancancer_map_mutation_class" name="PanCancer map mutation class" version="@VERSION@">
   <description>map mutation class</description>
   <macros>
     <import>macros.xml</import>

--- a/xml_files/pancancer_apply_weights.xml
+++ b/xml_files/pancancer_apply_weights.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_apply_weights" name="PanCancer_apply_weights" version="@VERSION@">
+<tool id="pancancer_apply_weights" name="PanCancer apply weights" version="@VERSION@">
   <description>apply weights</description>
   <macros>
     <import>macros.xml</import>

--- a/xml_files/pancancer_classifier.xml
+++ b/xml_files/pancancer_classifier.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_classifier" name="PanCancer_classifier" version="0.1.5" python_template_version="3.6">
+<tool id="pancancer_classifier" name="PanCancer classifier" version="0.1.5" python_template_version="3.6">
     <description>classifier for pathway aberrant activity</description>
     <macros>
         <import>macros.xml</import>

--- a/xml_files/pancancer_copy_burden_merge.xml
+++ b/xml_files/pancancer_copy_burden_merge.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_copy_burden_merge" name="PanCancer_copy_burden_merge" version="@VERSION@">
+<tool id="pancancer_copy_burden_merge" name="PanCancer copy burden merge" version="@VERSION@">
   <description>copy burden merge</description>
   <macros>
     <import>macros.xml</import>

--- a/xml_files/targene_cell_line_predictions.xml
+++ b/xml_files/targene_cell_line_predictions.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_targene_cell_line_predictions" name="PanCancer_targene_cell_line_predictions" version="@VERSION@">
+<tool id="pancancer_targene_cell_line_predictions" name="PanCancer targene cell line predictions" version="@VERSION@">
     <description>targene status in ccle cell lines </description>
     <macros>
         <import>macros.xml</import>

--- a/xml_files/targene_pathway_count_heatmaps.xml
+++ b/xml_files/targene_pathway_count_heatmaps.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_pathway_count_heatmaps" name="PanCancer_pathway_count_heatmaps" version="@VERSION@">
+<tool id="pancancer_pathway_count_heatmaps" name="PanCancer pathway count heatmaps" version="@VERSION@">
     <description>pathway count heatmaps</description>
     <macros>
         <import>macros.xml</import>

--- a/xml_files/targene_pharmacology.xml
+++ b/xml_files/targene_pharmacology.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_targene_pharmacology" name="PanCancer_targene_pharmacology" version="@VERSION@">
+<tool id="pancancer_targene_pharmacology" name="PanCancer targene pharmacology" version="@VERSION@">
     <description>ccle pharmocology predictions </description>
     <macros>
         <import>macros.xml</import>

--- a/xml_files/targene_summary_figures.xml
+++ b/xml_files/targene_summary_figures.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_targene_summary_figures" name="PanCancer_targene_summary_figures" version="@VERSION@">
+<tool id="pancancer_targene_summary_figures" name="PanCancer targene summary figures" version="@VERSION@">
   <description>Visualize targene summary</description>
   <macros>
     <import>macros.xml</import>

--- a/xml_files/visualize_decisions.xml
+++ b/xml_files/visualize_decisions.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_visualize_decisions" name="PanCancer_visualize_decisions" version="@VERSION@">
+<tool id="pancancer_visualize_decisions" name="PanCancer visualize decisions" version="@VERSION@">
   <description>visualize decisions</description>
   <macros>
     <import>macros.xml</import>

--- a/xml_files/within_disease_analysis.xml
+++ b/xml_files/within_disease_analysis.xml
@@ -1,4 +1,4 @@
-<tool id="pancancer_within_disease_analysis" name="PanCancer_within_disease_analysis" version="@VERSION@">
+<tool id="pancancer_within_disease_analysis" name="PanCancer within disease analysis" version="@VERSION@">
   <description>within disease analysis</description>
   <macros>
     <import>macros.xml</import>


### PR DESCRIPTION
Names+descriptions could use some more fine-tuning, but not currently critical.